### PR TITLE
Add standalone photography landing page with slideshow and galleries

### DIFF
--- a/photography.css
+++ b/photography.css
@@ -1,0 +1,218 @@
+:root {
+  color-scheme: light;
+  --text-primary: #111111;
+  --text-secondary: #5c5c5c;
+  --background: #fbfbf9;
+  --accent: #1a1a1a;
+  --muted: #e8e6e1;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", sans-serif;
+  background: var(--background);
+  color: var(--text-primary);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 32px 64px 16px;
+  position: sticky;
+  top: 0;
+  background: rgba(251, 251, 249, 0.9);
+  backdrop-filter: blur(6px);
+  z-index: 10;
+}
+
+.brand {
+  font-family: "Playfair Display", serif;
+  font-size: 1.4rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.nav {
+  display: flex;
+  gap: 12px;
+}
+
+.nav-link {
+  border: none;
+  background: transparent;
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  padding: 8px 12px;
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.nav-link.active,
+.nav-link:hover {
+  color: var(--accent);
+}
+
+main {
+  flex: 1;
+}
+
+.hero {
+  padding: 24px 64px 40px;
+}
+
+.slideshow {
+  position: relative;
+  height: min(70vh, 640px);
+  border-radius: 24px;
+  overflow: hidden;
+  background: #f0efeb;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.08);
+}
+
+.slides {
+  height: 100%;
+  position: relative;
+}
+
+.slide {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  transition: opacity 0.8s ease;
+}
+
+.slide.active {
+  opacity: 1;
+}
+
+.slide img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.slideshow-controls {
+  position: absolute;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  background: rgba(255, 255, 255, 0.75);
+  padding: 10px 16px;
+  border-radius: 999px;
+  backdrop-filter: blur(6px);
+}
+
+.control-button {
+  border: none;
+  background: transparent;
+  font-size: 1.1rem;
+  cursor: pointer;
+  color: var(--accent);
+}
+
+.dots {
+  display: flex;
+  gap: 8px;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: none;
+  background: var(--muted);
+  cursor: pointer;
+}
+
+.dot.active {
+  background: var(--accent);
+}
+
+.collection {
+  padding: 40px 64px;
+}
+
+.collection-header {
+  max-width: 560px;
+  margin-bottom: 24px;
+}
+
+.collection-header h2 {
+  font-family: "Playfair Display", serif;
+  font-size: 2.2rem;
+  margin: 0 0 12px;
+}
+
+.collection-header p {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.gallery-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.gallery-grid img {
+  width: 100%;
+  height: 240px;
+  object-fit: cover;
+  border-radius: 16px;
+}
+
+.footer {
+  padding: 32px 64px 48px;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.footer a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+@media (max-width: 900px) {
+  .top-bar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 24px;
+  }
+
+  .hero,
+  .collection,
+  .footer {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+
+  .slideshow {
+    height: 60vh;
+  }
+}
+
+@media (max-width: 600px) {
+  .nav {
+    flex-wrap: wrap;
+  }
+
+  .slideshow-controls {
+    width: calc(100% - 32px);
+    justify-content: space-between;
+  }
+}

--- a/photography.html
+++ b/photography.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="format-detection" content="telephone=no">
+  <title>Pedro Girardi Photography</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500&family=Playfair+Display:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="photography.css">
+</head>
+<body>
+  <header class="top-bar">
+    <div class="brand">Pedro Girardi Photography</div>
+    <nav class="nav" aria-label="Photography collections">
+      <button class="nav-link active" data-gallery="street">Street</button>
+      <button class="nav-link" data-gallery="portraits">Portraits</button>
+      <button class="nav-link" data-gallery="landscapes">Landscapes</button>
+    </nav>
+  </header>
+
+  <main>
+    <section class="hero" aria-label="Featured photographs">
+      <div class="slideshow" aria-live="polite">
+        <div class="slides">
+          <div class="slide active">
+            <img src="IMG_7449.JPG" alt="Street scene with dramatic light">
+          </div>
+          <div class="slide">
+            <img src="your-photo.jpg" alt="Portrait in soft daylight">
+          </div>
+          <div class="slide">
+            <img src="IMG_7449.JPG" alt="City silhouette in motion">
+          </div>
+          <div class="slide">
+            <img src="your-photo.jpg" alt="Quiet moment in monochrome tones">
+          </div>
+        </div>
+        <div class="slideshow-controls">
+          <button class="control-button" data-action="prev" aria-label="Previous slide">&#8592;</button>
+          <div class="dots" role="tablist" aria-label="Slide selection">
+            <button class="dot active" data-slide="0" aria-label="Go to slide 1"></button>
+            <button class="dot" data-slide="1" aria-label="Go to slide 2"></button>
+            <button class="dot" data-slide="2" aria-label="Go to slide 3"></button>
+            <button class="dot" data-slide="3" aria-label="Go to slide 4"></button>
+          </div>
+          <button class="control-button" data-action="next" aria-label="Next slide">&#8594;</button>
+        </div>
+      </div>
+    </section>
+
+    <section class="collection" id="street" data-gallery-section>
+      <div class="collection-header">
+        <h2>Street</h2>
+        <p>Quiet gestures, kinetic light, and fleeting moments stitched into the city rhythm.</p>
+      </div>
+      <div class="gallery-grid">
+        <img src="IMG_7449.JPG" alt="Street frame with contrast">
+        <img src="IMG_7449.JPG" alt="Architecture and passerby">
+        <img src="IMG_7449.JPG" alt="Shadows along the sidewalk">
+        <img src="IMG_7449.JPG" alt="Movement in the square">
+      </div>
+    </section>
+
+    <section class="collection" id="portraits" data-gallery-section hidden>
+      <div class="collection-header">
+        <h2>Portraits</h2>
+        <p>Intimate studies of expression and stillness, crafted with soft light and space.</p>
+      </div>
+      <div class="gallery-grid">
+        <img src="your-photo.jpg" alt="Portrait with gentle light">
+        <img src="your-photo.jpg" alt="Close-up portrait in profile">
+        <img src="your-photo.jpg" alt="Relaxed portrait in muted tones">
+        <img src="your-photo.jpg" alt="Portrait with minimal background">
+      </div>
+    </section>
+
+    <section class="collection" id="landscapes" data-gallery-section hidden>
+      <div class="collection-header">
+        <h2>Landscapes</h2>
+        <p>Open horizons and layered textures that linger between light and atmosphere.</p>
+      </div>
+      <div class="gallery-grid">
+        <img src="IMG_7449.JPG" alt="Landscape with long exposure light">
+        <img src="IMG_7449.JPG" alt="Wide view of urban horizon">
+        <img src="IMG_7449.JPG" alt="Soft tones across open space">
+        <img src="IMG_7449.JPG" alt="Minimal landscape composition">
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <p>For prints and commissions: <a href="mailto:contact@girardi.io">contact@girardi.io</a></p>
+  </footer>
+
+  <script src="photography.js"></script>
+</body>
+</html>

--- a/photography.js
+++ b/photography.js
@@ -1,0 +1,60 @@
+const slides = Array.from(document.querySelectorAll('.slide'));
+const dots = Array.from(document.querySelectorAll('.dot'));
+const controls = document.querySelectorAll('.control-button');
+const navLinks = document.querySelectorAll('.nav-link');
+const galleries = document.querySelectorAll('[data-gallery-section]');
+
+let currentSlide = 0;
+let slideshowTimer;
+
+const setSlide = (index) => {
+  slides[currentSlide].classList.remove('active');
+  dots[currentSlide].classList.remove('active');
+
+  currentSlide = (index + slides.length) % slides.length;
+
+  slides[currentSlide].classList.add('active');
+  dots[currentSlide].classList.add('active');
+};
+
+const nextSlide = () => setSlide(currentSlide + 1);
+const prevSlide = () => setSlide(currentSlide - 1);
+
+const startSlideshow = () => {
+  clearInterval(slideshowTimer);
+  slideshowTimer = setInterval(nextSlide, 6000);
+};
+
+controls.forEach((control) => {
+  control.addEventListener('click', () => {
+    const action = control.dataset.action;
+    if (action === 'prev') {
+      prevSlide();
+    } else {
+      nextSlide();
+    }
+    startSlideshow();
+  });
+});
+
+dots.forEach((dot, index) => {
+  dot.addEventListener('click', () => {
+    setSlide(index);
+    startSlideshow();
+  });
+});
+
+navLinks.forEach((link) => {
+  link.addEventListener('click', () => {
+    const target = link.dataset.gallery;
+    navLinks.forEach((item) => item.classList.remove('active'));
+    link.classList.add('active');
+
+    galleries.forEach((gallery) => {
+      const isTarget = gallery.id === target;
+      gallery.hidden = !isTarget;
+    });
+  });
+});
+
+startSlideshow();


### PR DESCRIPTION
### Motivation
- Create a refined, minimalist standalone photography landing page that is separate from the consulting site and emphasizes imagery through a hero slideshow and curated collection views.

### Description
- Add `photography.html` which contains the hero slideshow, slide dots and controls, and three collection sections (Street, Portraits, Landscapes) that can be toggled via the header navigation.
- Add `photography.css` implementing minimalist typography, spacing, slideshow visuals, responsive gallery grid, and subtle UI treatments to keep attention on the images.
- Add `photography.js` to provide automatic slideshow rotation, manual previous/next controls, dot navigation, and gallery switching behavior.

### Testing
- Served the site locally with `python -m http.server 8000` to validate files are reachable and the page loads successfully in a static preview.
- Attempted an end-to-end screenshot with Playwright but the Chromium process failed to launch in this environment so the capture did not complete.
- No unit or automated visual tests were added for the static assets in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69831229d6148328830001733a6bf32b)